### PR TITLE
add cleaner parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,13 @@ declare -a functionality=(
 ```
 To run Docker Volumes & Bind Mounts backups you need Docker environment.\
 To run Cloud Backup you have to have installed [rclone][rclone] and remote configured (named as *homeServerBackup*)
-
+For Daily-backup local and cloud cleaners you can specify how many backups you want to preserve
+```shell
+#   Choose how many daily backups you want to keep (daily-cleaner settings)
+declare -x -i dailyLocal=5
+declare -x -i dailyCloud=5
+#
+```
 ### 01. Directories & folders
 Set up your:
 * Backup Directory - local destination of backups

--- a/homeServerBackup.sh
+++ b/homeServerBackup.sh
@@ -269,13 +269,13 @@ fi
 #===========================================================================#
 #
 #   Execute these commands only for <daily> backups:
-#       Delete directiories (backups) older than 4 days
-#       (keep 5 backups: todays + 4 daily earliers)
+#       Delete older directiories (backups)
+#       (as specified in parameters.sh)
 #
 #   Local daily cleaner
 if  [[ "${functionality[*]}" =~ "Daily-backup cleaner" ]]; then
     if [ "$type" == "daily" ]; then
-        find "$backupDir"/"$type"/ -type d -mtime +4 -exec rm -rf "{}" \;
+        find "$backupDir"/"$type"/ -type d -mtime +"$((dailyLocal - 1))" -exec rm -rf "{}" \;
         echo "========================="
         echo "Daily-backup cleaner performed"
         echo "========================="
@@ -291,7 +291,7 @@ if  [[ "${functionality[*]}" =~ "Daily-backup cloud cleaner" ]]; then
             --volume "$backupDir":"$backupDir" \
             --user "$(id -u)":"$(id -g)" \
             rclone/rclone \
-            delete homeServerBackup:/ --min-age 5d
+            delete homeServerBackup:/ --min-age "$dailyCloud"d
             echo "========================="
             echo "Daily-backup cloud cleaner performed"
             echo "========================="

--- a/parameters-sample.sh
+++ b/parameters-sample.sh
@@ -2,7 +2,7 @@
 #
 #===========================================================================#
 #   
-#region | 00.   Functionality
+#region | 00.   Functionality and basic settings
 #
 #   Comment out with <#> features to exclude them from executing
 declare -a functionality=(
@@ -14,6 +14,10 @@ declare -a functionality=(
     'Daily-backup cloud cleaner'
     'Daily-backup archiver'
 )
+#
+#   Choose how many daily backups you want to keep (daily-cleaner settings)
+declare -x -i dailyLocal=5
+declare -x -i dailyCloud=5
 #
 #endregion
 #


### PR DESCRIPTION
Adding `dailyLocal` and `dailyCloud` parameters to easily set number of daily backups to preserve during Daily Cleaner (both locally and remotely). 